### PR TITLE
Resolves #3 by upgrading the Ignition version to 0.2.0

### DIFF
--- a/osvimdriver/pkg_info.json
+++ b/osvimdriver/pkg_info.json
@@ -1,4 +1,4 @@
 {
   "version": "0.2.0.dev0",
-  "ignition-version": "==0.1.0"
+  "ignition-version": "==0.2.0"
 }


### PR DESCRIPTION
Resolves #3.

Includes necessary changes to align the Find Infrastructure method on the Infrastructure Driver to return an empty result if matching infrastructure cannot be found