### PR TITLE
Upgrade ignition version. Implement usage of templateType field

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,5 +9,6 @@ Please read the following guides to get started with the VIM Driver
 ## Using the Driver
 
 - [Deployment Locations](./deployment_locations.md) - details the properties expected by this driver on a Deployment Location
+- [Supported Template Types](./supported_template_types.md) - details on supported infrastructure template types
 - [Supported Tosca](./supported_tosca.md) - details on supported infrastructure types
 - [APIs](./apis.md) - details additional APIs on this driver not expected by a VIM driver

--- a/docs/supported_template_types.md
+++ b/docs/supported_template_types.md
@@ -1,0 +1,10 @@
+# Template Types
+
+Currently the VIM driver supports two template types, however one of them is only usable when creating infrastructure:
+
+| Template Type | Create Infrastructure | Find Infrastructure |
+| --- | --- | --- |
+| TOSCA | Y | Y |
+| HEAT | Y | N |
+
+Heat is generally easier to use as Tosca requires translation, so it's behaviour depends on whether the types used can be translated or not. See [Supported Tosca](./supports_tosca.md) for more information.

--- a/osvimdriver/pkg_info.json
+++ b/osvimdriver/pkg_info.json
@@ -1,4 +1,4 @@
 {
   "version": "0.3.0.dev0",
-  "ignition-version": "==0.2.0"
+  "ignition-version": "==0.3.0"
 }


### PR DESCRIPTION
Now supports the use of Heat templates instead of Tosca. 
Closes #7 