### PR TITLE
Configure Helm chart to explicitly run the Docker image as the ovd user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ ENV WSGI_CONTAINER ${WSGI_CONTAINER:-uwsgi}
 COPY whls/*.whl /whls/
 
 RUN addgroup -S ovd \
- && adduser -S ovd -G ovd \
+ && adduser -S ovd -G ovd -u 100 \
  && mkdir -p /var/ovd \
  && chown -R ovd:ovd /var/ovd \
  && apk add --no-cache bash \

--- a/helm/os-vim-driver/templates/deployment.yaml
+++ b/helm/os-vim-driver/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         - name: os-vim-driver
           image: {{ .Values.docker.image }}:{{ .Values.docker.version }}
           imagePullPolicy: {{ .Values.docker.imagePullPolicy }}
+          securityContext:
+            # run as ovd
+            runAsUser: 100
           ports:
           - containerPort: 8292
             protocol: TCP


### PR DESCRIPTION
…he "ovd" user (to workaround https://github.com/kubernetes/kubernetes/issues/78308)